### PR TITLE
Add more language models to Leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ IceEval is a benchmark for evaluating and comparing the quality of pre-trained l
 - Operating System: Linux, e.g. Ubuntu
 - NVIDIA GPUs with CUDA support
 
+## Leaderboard
+
+On the **[Leaderboard](doc/results.md)** page, you can find current results of the most important Icelandic language models (LMs).
+
+
 ## Description
 
 IceEval is foremost a benchmark for evaluating and comparing the quality of pre-trained language models. The models are evaluated on a selection of four NLP tasks for Icelandic: part-of-speech (PoS) tagging, named entity recognition (NER), dependency parsing (DP) and automatic text summarization (ATS).
@@ -45,10 +50,6 @@ TransformerSum - https://github.com/HHousen/TransformerSum<br>
 **Note:**<br>
 The TransformerSum library uses a `ROUGE` package that isn't Unicode-friendly. This mimics the original `ROUGE` package for Perl which wasn't Unicode friendly either. When calculating `ROUGE` scores, first the GOLD and predicted summaries are pre-processed by discarding all non-alphanumeric characters using the regular expression `[^a-z0-9]+`. This would result in all accented characters being replaced by spaces, which leads to much lower `ROUGE` scores. In our bundled version of `TransformerSum`, this issue has been fixed. English-oriented stemming on the summaries is also fixed.
 
-## Results
-
-Evaluation results of many Icelandic language models (LMs) can be found in the [results](doc/results.md) section.
-
 ## Installation
 
 Install all required packages:
@@ -62,13 +63,13 @@ pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable
 Download and process the datasets:
 
 ``` shell
-python download_datasets.py
+python3 download_datasets.py
 ```
 
 Run the benchmark:
 
 ``` shell
-python finetune.py --model_path <path_to_model> --model_type <model_type> --output_dir <output_dir>
+python3 finetune.py --model_path <path_to_model> --model_type <model_type> --output_dir <output_dir>
 ```
 
 The argument `--path_to_model` specifies the path to pretrained model or model identifier from huggingface.co/models. You can also use the syntax `<group>/<model>@<revision>` to specify a certain version on HuggingFace.<br>
@@ -78,10 +79,25 @@ The argument `--path_to_model` specifies the path to pretrained model or model i
 Print results:
 
 ``` shell
-python get_results.py <root_dir>
+python3 get_results.py <root_dir>
 ```
 
 The `root_dir` argument specifies an output folder that was generated when running the benchmark with finetune.py. You can also run this script while the fine-tuning process is ongoing.
+
+Generate detailed results for PoS-Tagging:
+
+```bash
+python3 eval_pos.py --splits_dir <path-to-mim-gold> \
+          --results_dir <root_dir/pos> \
+          --output_dir <output_dir> \
+          --ignore_tags <space separated list of tags to be excluded from eval, e.g. B-x B-e> \
+          --confusion_matrix \
+          --full
+```
+
+This will generate results of the model as graphical confusion matrices of the top 30 mis-classifications and additional text files with more details inside a subfolder `confusions/` inside the given output directory.<br>
+If option `--full` is given, the full set of test data is used for evaluation, instead of just the part of the test data that fits into the max. input sequence of the model.<br>
+Optionally, parameter `--ignore_tags` can be used to specify a list of tags that should not be used for the evaluation. Note however, that the model still can predict these tags, and therefore you either need to train the model excluding these tags or need to modify the weights of these tags inside the classifier layer of the trained model to get the highest prediction accuracies. 
 
 ## License
 

--- a/doc/results.md
+++ b/doc/results.md
@@ -1,32 +1,35 @@
-## Results for Icelandic LM's
+## Leaderboard of Icelandic LM's
 
-This overview shows our evaluation results for various Icelandic LM's available via HuggingFace.
+This overview shows our evaluation results for the most important Icelandic Language Models available via HuggingFace.
 
-Each model evaluation has been run in `October/2024` on a single GPU card with script default values.<br>
-**These scores are evaluated after a constant training length for each model and represent the lower bounds that are possible, if training would continue.**<br>
+Each model evaluation has been run in `October/2024` on a single GPU card with **script default values**.<br>
 
-The given **rank is calculated by averaging all final scores** and is an orientation for the best performing all-rounders.<br>
-Missing values are from models currently under evaluation.
+**These scores are evaluated after a constant training length for each model and represent the lower bounds. Higher values are possible, if training time is higher/unbound and early stopping is applied.**<br>
 
-| Model | License | Parameters | Model-Size | PoS`*` | NER | DP`**` | ATS | Rank |
-|-------|---------|------------|------------|-----|-----|----|----|------|
-| jonfd/convbert-base-igc-is | CC-BY-4.0 | 106.90 Mio | 407.78 MB | 97.71% | 91.52% | 79.84% | 69.09% | 2 |
-| jonfd/convbert-small-igc-is | CC-BY-4.0 | 21.52 Mio | 82.12 MB | 96.94% | 89.95% | 79.46% | 68.74% | 3 |
-| jonfd/electra-base-igc-is | CC-BY-4.0 | 110.11 Mio | 420.03 MB | 97.67% | 90.96% | 81.11% | 70.80% | 1 |
-| jonfd/electra-small-igc-is | CC-BY-4.0 | 13.69 Mio | 52.21 MB | 96.86% | 88.00% | 78.40% | 68.67% | 5 |
-| jonfd/electra-small-is-no | CC-BY-4.0 | 17.78 Mio | 67.84 MB | | | | | |
-| jonfd/gpt2-igc-is | CC-BY-4.0 | 125.01 Mio | 488.88 MB | | | | | |
-| MaCoCu/XLMR-base-MaCoCu-is | CC0 1.0 Universal | 278.04 Mio | 1060.66 MB | | | | | |
-| MaCoCu/XLMR-MaCoCu-is | CC0 1.0 Universal | 559.89 Mio | 2135.82 MB | | | | | |
-| mideind/IceBERT | AGPLv3 | 124.44 Mio | 474.72 MB | 97.88% | 92.40% | 72.51% | 69.91% | 4 |
-| mideind/IceBERT-igc | AGPLv3 | 124.44 Mio | 474.72 MB | | | | | |
-| mideind/IceBERT-large | AGPLv3 | 355.09 Mio | 1354.56 MB | | | | | |
+- The score values show for PoS: Accuracy, NER: f1, DP: LAS, ATS: ROUGE-2 recall
+- The given **rank is calculated by averaging all final scores** and is an orientation for the best performing all-rounders
+- Highest values of individual categories are written in **bold** letters, lowest in *italic* letters. Additionally, ↑↓ mark the highest/lowest value in each category
 
-`*` For a possible upper bound of this value, see the paper [Is Part-of-Speech Tagging a Solved Problem for Icelandic?](https://aclanthology.org/2023.nodalida-1.8.pdf)<br>
-`**` Note that results for DiaParser are significantly lower than expected, need investigation!
+| Rank | Model                                                                                           | PoS`*`          | NER          | DP           | ATS`**`      | Parameters       | Model-Size       | License                                                           |
+|------|------------------------------------------------------------------------------------------------|-----------------|--------------|--------------|--------------|------------------|------------------|-------------------------------------------------------------------|
+| 1    | [MaCoCu/XLMR-MaCoCu-is](https://huggingface.co/MaCoCu/XLMR-MaCoCu-is)                           | **98.00%** ↑`¹` | 92.11% `²`   | **84.69%** ↑ | **71.58%** ↑ | **559.89 Mio** ↑ | **2135.82 MB** ↑ | [CC0 1.0 Universal](https://choosealicense.com/licenses/cc0-1.0/) |
+| 2    | [icelandic-lt/electra-base-igc-is](https://huggingface.co/icelandic-lt/electra-base-igc-is)     | 97.67%          | 90.96%       | 84.10%       | 71.24%       | 110.11 Mio       | 420.03 MB        | [CC-BY-4.0](https://choosealicense.com/licenses/cc-by-4.0/)       |
+| 3    | [icelandic-lt/convbert-base-igc-is](https://huggingface.co/icelandic-lt/convbert-base-igc-is)   | 97.71%          | 91.52%       | 84.34%       | 69.09%       | 106.90 Mio       | 407.78 MB        | [CC-BY-4.0](https://choosealicense.com/licenses/cc-by-4.0/)       |
+| 4    | [MaCoCu/XLMR-base-MaCoCu-is](https://huggingface.co/MaCoCu/XLMR-base-MaCoCu-is)                 | 97.23%          | 89.45%       | 83.12%       | 70.07%       | 278.04 Mio       | 1060.66 MB       | [CC0 1.0 Universal](https://choosealicense.com/licenses/cc0-1.0/) |
+| 5    | [mideind/IceBERT](https://huggingface.co/mideind/IceBERT)                                       | 97.88%          | **92.40%** ↑ | 78.87%       | 69.91%       | 124.44 Mio       | 474.72 MB        | [AGPLv3](https://choosealicense.com/licenses/agpl-3.0/)           |
+| 6    | [icelandic-lt/convbert-small-igc-is](https://huggingface.co/icelandic-lt/convbert-small-igc-is) | 96.94%          | 89.95%       | 82.87%       | 68.74%       | 21.52 Mio        | 82.12 MB         | [CC-BY-4.0](https://choosealicense.com/licenses/cc-by-4.0/)       |
+| 7    | [mideind/IceBERT-large](https://huggingface.co/mideind/IceBERT-large)                           | 97.69%          | 90.98%`³`    | 78.41%       | 71.20%       | 355.09 Mio       | 1354.56 MB       | [AGPLv3](https://choosealicense.com/licenses/agpl-3.0/)           |
+| 8    | [icelandic-lt/electra-small-igc-is](https://huggingface.co/icelandic-lt/electra-small-igc-is)   | 96.86%          | *88.00%* ↓   | 82.10%       | *68.67%* ↓   | *13.69 Mio* ↓    | *52.21 MB* ↓     | [CC-BY-4.0](https://choosealicense.com/licenses/cc-by-4.0/)       |
+| 9    | [mideind/IceBERT-igc](https://huggingface.co/mideind/IceBERT-igc)                               | 97.36%          | 90.27%       | *78.10%* ↓   | 69.67%       | 124.44 Mio       | 474.72 MB        | [AGPLv3](https://choosealicense.com/licenses/agpl-3.0/)           |
+| 10   | [jonfd/electra-small-is-no](https://huggingface.co/jonfd/electra-small-is-no)                   | *96.63%* ↓      | 88.19%       | 81.66%       | 68.86%       | 17.78 Mio        | 67.84 MB         | [CC-BY-4.0](https://choosealicense.com/licenses/cc-by-4.0/)       |
 
+`*` For possible upper bounds of this value, see paper [Is Part-of-Speech Tagging a Solved Problem for Icelandic?](https://aclanthology.org/2023.nodalida-1.8.pdf)<br>
+`**` Best value from 2 runs with either 5 or 10 epochs training<br>
+`¹` Model achieves SOTA results (98.19% accuracy when excluding evaluation for x, e tags) for **single-label PoS tagging** in Icelandic just with standard fine-tuning procedures<br>
+`²` Fold 5 training was not converging with the standard seed 42, therefore the seed parameter was changed to 43 in that particular case<br>
+`³` Same as for `²` but for folds 5, 6, 7
 
-Besides absolute scores for a specific use-case, please take also into account the license of the specific model and its size / number of model parameters.<br>
-The runtime is roughly anti-proportional to the model's parameter count.
+Besides absolute scores for a specific task, please take also into account the license of the specific model and its size / number of model parameters.<br>
+The inference speed is roughly anti-proportional to the model's parameter count.
 
-**If you think, that an important model is missing from this evaluation, open an [issue](https://github.com/icelandic-lt/IceEval/issues) inside this repository, and we try to add the missing info.**
+**If you think, that an important model is missing from this evaluation or if you like to inquire for specific evaluation results or fine-tuned models, please open an [issue](https://github.com/icelandic-lt/IceEval/issues) inside this repository.**

--- a/eval_pos.py
+++ b/eval_pos.py
@@ -1,0 +1,171 @@
+import json
+import os
+import argparse
+from typing import List, Tuple
+from collections import Counter
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def load_json(file_path: str) -> List[dict]:
+    with open(file_path, 'r', encoding='utf-8') as f:
+        return [json.loads(line) for line in f]
+
+
+def load_predictions(file_path: str) -> List[List[str]]:
+    with open(file_path, 'r', encoding='utf-8') as f:
+        return [line.strip().split() for line in f]
+
+def calculate_accuracy(gold_tags: List[str], pred_tags: List[str], ignore_tags: List[str]) -> Tuple[int, int]:
+    correct = sum(1 for g, p in zip(gold_tags, pred_tags) if g == p and g not in ignore_tags)
+    total = sum(1 for g in gold_tags if g not in ignore_tags)
+    return correct, total
+
+
+def get_top_n_incorrect_predictions(gold_tags, pred_tags, top_n):
+    # Count all incorrect predictions
+    incorrect_predictions = Counter()
+    for gold, pred in zip(gold_tags, pred_tags):
+        if gold != pred:
+            incorrect_predictions[(gold, pred)] += 1
+
+    # Sort by frequency in descending order
+    sorted_predictions = sorted(incorrect_predictions.items(), key=lambda x: x[1], reverse=True)
+    return sorted_predictions[:top_n] if top_n is not None else sorted_predictions
+
+
+def save_top_confusions(gold_tags, pred_tags, top_n, output_file):
+    top_confusions = get_top_n_incorrect_predictions(gold_tags, pred_tags, top_n)
+
+    with open(output_file, 'w') as f:
+        f.write("True Label\tPredicted Label\tCount\n")
+        for (true_label, pred_label), count in top_confusions:
+            f.write(f"{true_label}\t{pred_label}\t{count}\n")
+
+
+def evaluate_fold(test_file: str, pred_file: str, ignore_tags: List[str], full: bool, fold: int, output_dir: str, plot_cm: bool) -> Tuple[float, int, bool, List[str], List[str]]:
+    gold_data = load_json(test_file)
+    pred_data = load_predictions(pred_file)
+
+    total_correct = 0
+    total_tokens = 0
+    discrepancy_found = False
+    all_gold_tags = []
+    all_pred_tags = []
+
+    for gold, pred in zip(gold_data, pred_data):
+        gold_tags = gold['tags']
+        if len(gold_tags) != len(pred):
+            discrepancy_found = True
+
+        if full:
+            eval_gold_tags = gold_tags
+            eval_pred_tags = pred
+        else:
+            eval_gold_tags = gold_tags[:len(pred)]
+            eval_pred_tags = pred
+
+        correct, total = calculate_accuracy(eval_gold_tags, eval_pred_tags, ignore_tags)
+        total_correct += correct
+        total_tokens += total
+
+        for g, p in zip(eval_gold_tags, eval_pred_tags):
+            if g not in ignore_tags:
+                all_gold_tags.append(g)
+                all_pred_tags.append(p)
+
+    fold_accuracy = total_correct / total_tokens if total_tokens > 0 else 0
+
+    top_confusions_file = os.path.join(output_dir, f'top_confusions_fold_{fold}.tsv')
+    save_top_confusions(all_gold_tags, all_pred_tags, 50, top_confusions_file)
+
+    if plot_cm:
+        cm_file = os.path.join(output_dir, f'confusion_matrix_fold_{fold}.png')
+        create_confusion_matrix(all_gold_tags, all_pred_tags, 30, cm_file)
+
+    return fold_accuracy, total_tokens, discrepancy_found, all_gold_tags, all_pred_tags
+
+
+def plot_confusion_matrix(cm, classes, title, output_file):
+    plt.figure(figsize=(10, 8))
+    plt.imshow(cm, interpolation='nearest', cmap=plt.cm.Blues)
+    plt.title(title)
+    plt.colorbar()
+    tick_marks = np.arange(len(classes))
+    plt.xticks(tick_marks, classes, rotation=45, ha='right')
+    plt.yticks(tick_marks, classes)
+    plt.ylabel('True label')
+    plt.xlabel('Predicted label')
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=300, bbox_inches='tight')
+    plt.close()
+
+
+def create_confusion_matrix(gold_tags, pred_tags, top_n, output_file):
+    top_confusions = get_top_n_incorrect_predictions(gold_tags, pred_tags, top_n)
+
+    # Get unique labels from top confusions
+    unique_labels = sorted(set(gold for (gold, _), _ in top_confusions) |
+                           set(pred for (_, pred), _ in top_confusions))
+
+    # Create confusion matrix
+    cm = np.zeros((len(unique_labels), len(unique_labels)), dtype=int)
+    label_to_index = {label: i for i, label in enumerate(unique_labels)}
+
+    for (true, pred), count in top_confusions:
+        true_index = label_to_index[true]
+        pred_index = label_to_index[pred]
+        cm[true_index][pred_index] = count
+
+    # Plot the confusion matrix
+    plot_confusion_matrix(cm, unique_labels, f'Top {top_n} Misclassifications', output_file)
+
+
+def main(splits_dir: str, results_dir: str, ignore_tags: List[str], full: bool, output_dir: str, plot_cm: bool):
+    total_correct = 0
+    total_tokens = 0
+    all_gold_tags = []
+    all_pred_tags = []
+
+    for fold in range(1, 11):
+        test_file = os.path.join(splits_dir, f'{fold:02d}-test.json')
+        pred_file = os.path.join(results_dir, f'{fold:02d}', 'predictions.txt')
+
+        print(f"\nProcessing Fold {fold:02d}")
+        fold_accuracy, fold_tokens, discrepancy, fold_gold_tags, fold_pred_tags = evaluate_fold(test_file, pred_file, ignore_tags, full, fold, output_dir, plot_cm)
+        total_correct += fold_accuracy * fold_tokens
+        total_tokens += fold_tokens
+        all_gold_tags.extend(fold_gold_tags)
+        all_pred_tags.extend(fold_pred_tags)
+
+        print(f"Fold {fold:02d} Accuracy: {fold_accuracy:.4f} (Tokens: {fold_tokens})")
+        if discrepancy:
+            print(f"Warning: Discrepancy found in Fold {fold:02d}. Some sequences have different lengths in gold and prediction data.")
+
+    overall_accuracy = total_correct / total_tokens if total_tokens > 0 else 0
+    print(f"\nOverall Accuracy: {overall_accuracy:.4f} (Total Tokens: {total_tokens})")
+
+    top_confusions_file = os.path.join(output_dir, 'top_confusions_overall.tsv')
+    save_top_confusions(all_gold_tags, all_pred_tags, 50, top_confusions_file)
+
+    if plot_cm:
+        cm_file = os.path.join(output_dir, 'confusion_matrix_overall.png')
+        create_confusion_matrix(all_gold_tags, all_pred_tags, 30, cm_file)
+
+    if not full:
+        print("Note: Evaluation was performed on truncated sequences matching prediction lengths.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Evaluate POS tagging accuracy across folds")
+    parser.add_argument("--splits_dir", required=True, help="Directory containing the fold splits for training")
+    parser.add_argument("--results_dir", required=True,
+                        help="Directory containing the results (parent directory of fold results)")
+    parser.add_argument("--ignore_tags", nargs="+", default=[], help="List of tags to ignore in evaluation")
+    parser.add_argument("--full", action="store_true", help="Evaluate full sequences, including untagged tokens")
+    parser.add_argument("--output_dir", default=".", help="Directory to save output files")
+    parser.add_argument("--confusion_matrix", action="store_true", help="Generate confusion matrix plots")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    main(args.splits_dir, args.results_dir, args.ignore_tags, args.full, args.output_dir, args.confusion_matrix)

--- a/finetune.py
+++ b/finetune.py
@@ -20,7 +20,7 @@ def split_model_and_revision(model_path):
         return match.group(1), match.group(2)
     return model_path, None
 
-def finetune_pos(model_path, train_path, test_path, output_path, task, batch_size=16, learning_rate=5e-5, epochs=10, force=False):
+def finetune_pos(model_path, train_path, test_path, output_path, task, **kwargs):
     """Finetune a pre-trained language model on a token classification task.
 
     :param model_path: Path to pretrained model or model identifier from huggingface.co/models.
@@ -28,14 +28,11 @@ def finetune_pos(model_path, train_path, test_path, output_path, task, batch_siz
     :param test_path: The input test data file to predict on (a csv or JSON file).
     :param output_path: The output directory where the model predictions and checkpoints will be written.
     :param task: The name of the task.
-    :param batch_size: Batch size for training.
-    :param learning_rate: The learning rate.
-    :param epochs: Total number of training epochs to perform.
-    :param force: overwrite existing folder.
+    :param kwargs: Additional keyword arguments.
     :return:
     """
     if os.path.exists(output_path):
-        if force:
+        if kwargs.get('force', False):
             shutil.rmtree(output_path)
         else:
             logging.info(f"Already exists: {output_path}")
@@ -55,13 +52,13 @@ def finetune_pos(model_path, train_path, test_path, output_path, task, batch_siz
            '--do_predict',
            '--text_column_name', 'tokens',
            '--label_column_name', 'tags',
-           '--learning_rate', str(learning_rate),
-           '--per_device_train_batch_size', str(batch_size),
+           '--learning_rate', str(kwargs.get('learning_rate')),
+           '--per_device_train_batch_size', str(kwargs.get('batch_size')),
            '--per_device_eval_batch_size', '256',
            '--eval_accumulation_steps', '8',
            '--save_steps', '0',
-           '--num_train_epochs', str(epochs),
-           '--seed', '42',
+           '--num_train_epochs', str(kwargs.get('epochs')),
+           '--seed', str(kwargs.get('seed')),
            '--logging_step', '500',
            '--overwrite_cache',
            ]
@@ -74,7 +71,7 @@ def finetune_pos(model_path, train_path, test_path, output_path, task, batch_siz
         raise RuntimeError(f"Subprocess failed: finetune_pos for {output_path}")
 
 
-def finetune_dp(model_path, train_path, val_path, test_path, output_path, epochs=200, cwd=None, force=False):
+def finetune_dp(model_path, train_path, val_path, test_path, output_path, **kwargs):
     """Finetune a pre-trained language model on dependency parsing.
 
     :param model_path: Path to pretrained model or model identifier from huggingface.co/models.
@@ -82,13 +79,11 @@ def finetune_dp(model_path, train_path, val_path, test_path, output_path, epochs
     :param val_path: The input evaluation data file to evaluate on (a csv or JSON file).
     :param test_path: The input test data file to predict on (a csv or JSON file).
     :param output_path: The output directory where the checkpoints and log will be written.
-    :param epochs: Total number of training epochs to perform.
-    :param cwd: The working directory where the training script should be executed from.
-    :param force: overwrite existing folder.
+    :param kwargs: Additional keyword arguments.
     :return:
     """
     if os.path.exists(output_path):
-        if force:
+        if kwargs.get('force', False):
             shutil.rmtree(output_path)
         else:
             logging.info(f"Already exists: {output_path}")
@@ -98,11 +93,11 @@ def finetune_dp(model_path, train_path, val_path, test_path, output_path, epochs
     cmd = [PYTHON,
            '-X', 'utf8',
            '-m', 'diaparser.cmds.biaffine_dependency', 'train',
-           '--epochs', str(epochs),
+           '--epochs', str(kwargs.get('epochs')),
            '--build',
            '--device', '0',
            '--path', output_path,
-           '--seed', '42',
+           '--seed', str(kwargs.get('seed')),
            '--train', train_path,
            '--dev', val_path,
            '--test', test_path,
@@ -111,28 +106,24 @@ def finetune_dp(model_path, train_path, val_path, test_path, output_path, epochs
            ]
 
     logging.info(" ".join(cmd))
-    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    result = subprocess.run(cmd, cwd=kwargs.get('cwd'), capture_output=True, text=True)
     if result.returncode != 0:
         logging.error(f"Error in finetune_dp for {output_path}:")
         logging.error(result.stderr)
         raise RuntimeError(f"Subprocess failed: finetune_dp for {output_path}")
 
 
-def finetune_ats(model_path, model_type, data_path, output_path, batch_size, epochs, classifier, pooling_mode, force=False):
+def finetune_ats(model_path, model_type, data_path, output_path, **kwargs):
     """Finetune a pre-trained language model on extractive text summarization.
 
     :param model_path: Path to pretrained model or model identifier from huggingface.co/models.
     :param model_type: The type of the model (e.g., 'bert', 'roberta' or 'electra').
     :param data_path: Path to the training, validation and test files.
     :param output_path: The output directory where the checkpoints and results will be written.
-    :param batch_size: Batch size for training.
-    :param epochs: Total number of training epochs to perform.
-    :param classifier: Which classifier/encoder to use to reduce the hidden dimension of the sentence vectors.
-    :param pooling_mode: How word vectors should be converted to sentence embeddings.
-    :param force: overwrite existing folder.
+    :param kwargs: Additional keyword arguments.
     """
     if os.path.exists(output_path):
-        if force:
+        if kwargs.get('force', False):
             shutil.rmtree(output_path)
         else:
             logging.info(f"Already exists: {output_path}")
@@ -149,13 +140,14 @@ def finetune_ats(model_path, model_type, data_path, output_path, batch_size, epo
            '--default_root_dir', output_path,
            '--do_train',
            '--do_test',
-           '--max_epochs', str(epochs),
+           '--max_epochs', str(kwargs.get('epochs')),
            '--use_logger', 'tensorboard',
-           '--batch_size', str(batch_size),
-           '--classifier', classifier,
+           '--batch_size', str(kwargs.get('batch_size')),
+           '--classifier', kwargs.get('classifier'),
            '--no_use_token_type_ids',
            '--no_test_block_trigrams',
-           '--pooling_mode', pooling_mode]
+           '--pooling_mode', kwargs.get('pooling_mode'),
+           '--seed', str(kwargs.get('seed'))]
 
     logging.info(" ".join(cmd))
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -174,6 +166,9 @@ def main():
     parser.add_argument("-o", "--output_dir", help="Where to write the checkpoints and results during fine-tuning.",
                         required=True)
     parser.add_argument("-f", "--force", action="store_true", default=False, help="Force overwrite of existing output directories")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility")
+    parser.add_argument("--tasks", nargs='+', default=['pos', 'ner', 'dp', 'ats'],
+                        help="Tasks to run. Can be any combination of 'pos', 'ner', 'dp', 'ats'")
     args = parser.parse_args()
 
     task_args = {
@@ -183,11 +178,18 @@ def main():
         'ats': {'epochs': 5, 'batch_size': 8, 'classifier': 'linear', 'pooling_mode': 'mean_tokens'}
     }
 
-    tasks = ['pos', 'ner', 'dp', 'ats']
-
     model_path = args.model_path
     model_type = args.model_type
     force = args.force
+    seed = args.seed
+    tasks = args.tasks
+
+    # Validate tasks
+    valid_tasks = {'pos', 'ner', 'dp', 'ats'}
+    invalid_tasks = set(tasks) - valid_tasks
+    if invalid_tasks:
+        logging.error(f"Invalid tasks specified: {', '.join(invalid_tasks)}")
+        sys.exit(1)
 
     # Default dataset path is the 'dataset' directory where this script is located
     script_path = os.path.realpath(__file__)
@@ -225,9 +227,10 @@ def main():
                 train_path = os.path.join(dataset_dir, f'{fold}-train.json')
                 test_path = os.path.join(dataset_dir, f'{fold}-test.json')
                 output_path = os.path.join(output_dir, 'pos', fold)
-                args = task_args['pos']
+                finetune_args = task_args['pos'].copy()
+                finetune_args.update({'force': force, 'seed': seed})
 
-                finetune_pos(model_path, train_path, test_path, output_path, **args, force=force)
+                finetune_pos(model_path, train_path, test_path, output_path, **finetune_args)
 
         # Named entity recognition
         if 'ner' in tasks:
@@ -237,8 +240,10 @@ def main():
                 train_path = os.path.join(dataset_dir, f'{fold}-train.json')
                 test_path = os.path.join(dataset_dir, f'{fold}-test.json')
                 output_path = os.path.join(output_dir, 'ner', fold)
+                finetune_args = task_args['ner'].copy()
+                finetune_args.update({'force': force, 'seed': seed})
 
-                finetune_pos(model_path, train_path, test_path, output_path, **task_args['ner'], force=force)
+                finetune_pos(model_path, train_path, test_path, output_path, **finetune_args)
 
         # Dependency parsing
         if 'dp' in tasks:
@@ -247,12 +252,13 @@ def main():
             train_path = os.path.join(dataset_dir, 'is_icepahc-ud-train.conllu')
             val_path = os.path.join(dataset_dir, 'is_icepahc-ud-dev.conllu')
             test_path = os.path.join(dataset_dir, 'is_icepahc-ud-test.conllu')
-            epochs = task_args['dp']['epochs']
+            finetune_args = task_args['dp'].copy()
+            finetune_args.update({'force': force, 'seed': seed, 'cwd': lib_dir})
 
             for num_run in runs:
                 output_path = os.path.join(output_dir, 'dp', num_run, num_run)
 
-                finetune_dp(model_path, train_path, val_path, test_path, output_path, epochs, cwd=lib_dir, force=force)
+                finetune_dp(model_path, train_path, val_path, test_path, output_path, **finetune_args)
 
         # Automatic text summarization
         if 'ats' in tasks:
@@ -266,9 +272,12 @@ def main():
                     path_to = os.path.join(ats_dataset_dir, icesum_file)
                     shutil.copy(path_from, path_to)
 
+            finetune_args = task_args['ats'].copy()
+            finetune_args.update({'force': force, 'seed': seed})
+
             for num_run in runs:
                 output_path = os.path.join(output_dir, 'ats', num_run)
-                finetune_ats(model_path, model_type, ats_dataset_dir, output_path, **task_args['ats'], force=force)
+                finetune_ats(model_path, model_type, ats_dataset_dir, output_path, **finetune_args)
     except RuntimeError as e:
         logging.error(f"Script terminated due to an error: {str(e)}")
         sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 accelerate >= 0.12.0
-datasets
-diaparser
-evaluate
+datasets~=3.0.1
+evaluate~=0.4.3
 numpy==1.25.2
-requests
+requests==2.32.3
 rouge-score
 seqeval
 tokenizer==2.0
@@ -11,3 +10,10 @@ torch >= 1.3,<2
 transformers[torch]>=4.45.0
 pytorch-lightning>=1.4.4,<1.6.0
 torch-optimizer
+tqdm~=4.66.5
+nltk~=3.9.1
+stanza~=1.2.3
+packaging~=24.1
+pyarrow~=17.0.0
+matplotlib~=3.9.2
+scikit-learn~=1.5.2


### PR DESCRIPTION
**TLDR;  we have a new PoS Tagger SOTA model !**


 **finetune.py: add options --seed, --tasks**

Option --seed adds possibility to set the seed value used at training time.
Default stays at value 42.

Option --tasks adds possibility to run only specific tasks, instead of all.
Default is to run all tasks

**eval_pos.py: Detailed Evaluation of PoS tagging task**

This script evaluates more detailed the PoS tagging results of specific models
by evaluating each fold and all folds together:

- generates confusion matrices of top 30 mis-classifications
- generates tsv files with detailed statistics of mis-classifications
- generates tsv files with gold-standard tags and predictions side-by-side

**fine_tune.py: increase epochs for dp, ats**

- Increase number of epochs for tasks dp. The previous results of dp
  showed too small values. The new values are more realistic.
- Add missing evaluations for all models, revamp order of evaluation result columns
- Reevaluate previously tested models with new epoch values for
  dp (15 epochs) & ats (10 epochs) and set ranks accordingly.
  Use higher result values for evaluation
- Evaluate CUDA_VISIBLE_DEVICES for task dp instead of fixing cuda device
  to 0
- Rename Results => Leaderboard; this is a much better name
- Update usage for `eval_pos.py`
- update `requirements.txt` for more specific versions and add more dependencies

